### PR TITLE
Add missing @font-face calls for italic styles

### DIFF
--- a/source-serif-pro.css
+++ b/source-serif-pro.css
@@ -3,11 +3,21 @@
     font-weight: 200;
     font-style: normal;
     font-stretch: normal;
-    src: url('EOT/SourceSerifPro-ExtraLight.eot') format('embedded-opentype'),
+    src: url('WOFF2/TTF/SourceSerifPro-ExtraLight.ttf.woff2') format('woff2'),
          url('WOFF/OTF/SourceSerifPro-ExtraLight.otf.woff') format('woff'),
-         url('WOFF2/OTF/SourceSerifPro-ExtraLight.otf.woff2') format('woff2'),
          url('OTF/SourceSerifPro-ExtraLight.otf') format('opentype'),
          url('TTF/SourceSerifPro-ExtraLight.ttf') format('truetype');
+}
+
+@font-face{
+    font-family: 'Source Serif Pro';
+    font-weight: 200;
+    font-style: italic;
+    font-stretch: normal;
+    src: url('WOFF2/TTF/SourceSerifPro-ExtraLightIt.ttf.woff2') format('woff2'),
+         url('WOFF/OTF/SourceSerifPro-ExtraLightIt.otf.woff') format('woff'),
+         url('OTF/SourceSerifPro-ExtraLightIt.otf') format('opentype'),
+         url('TTF/SourceSerifPro-ExtraLightIt.ttf') format('truetype');
 }
 
 @font-face{
@@ -15,11 +25,21 @@
     font-weight: 300;
     font-style: normal;
     font-stretch: normal;
-    src: url('EOT/SourceSerifPro-Light.eot') format('embedded-opentype'),
+    src: url('WOFF2/TTF/SourceSerifPro-Light.ttf.woff2') format('woff2'),
          url('WOFF/OTF/SourceSerifPro-Light.otf.woff') format('woff'),
-         url('WOFF2/OTF/SourceSerifPro-Light.otf.woff2') format('woff2'),
          url('OTF/SourceSerifPro-Light.otf') format('opentype'),
          url('TTF/SourceSerifPro-Light.ttf') format('truetype');
+}
+
+@font-face{
+    font-family: 'Source Serif Pro';
+    font-weight: 300;
+    font-style: italic;
+    font-stretch: normal;
+    src: url('WOFF2/TTF/SourceSerifPro-LightIt.ttf.woff2') format('woff2'),
+         url('WOFF/OTF/SourceSerifPro-LightIt.otf.woff') format('woff'),
+         url('OTF/SourceSerifPro-LightIt.otf') format('opentype'),
+         url('TTF/SourceSerifPro-LightIt.ttf') format('truetype');
 }
 
 @font-face{
@@ -27,11 +47,21 @@
     font-weight: 400;
     font-style: normal;
     font-stretch: normal;
-    src: url('EOT/SourceSerifPro-Regular.eot') format('embedded-opentype'),
+    src: url('WOFF2/TTF/SourceSerifPro-Regular.ttf.woff2') format('woff2'),
          url('WOFF/OTF/SourceSerifPro-Regular.otf.woff') format('woff'),
-         url('WOFF2/OTF/SourceSerifPro-Regular.otf.woff2') format('woff2'),
          url('OTF/SourceSerifPro-Regular.otf') format('opentype'),
          url('TTF/SourceSerifPro-Regular.ttf') format('truetype');
+}
+
+@font-face{
+    font-family: 'Source Serif Pro';
+    font-weight: 400;
+    font-style: italic;
+    font-stretch: normal;
+    src: url('WOFF2/TTF/SourceSerifPro-It.ttf.woff2') format('woff2'),
+         url('WOFF/OTF/SourceSerifPro-It.otf.woff') format('woff'),
+         url('OTF/SourceSerifPro-It.otf') format('opentype'),
+         url('TTF/SourceSerifPro-It.ttf') format('truetype');
 }
 
 @font-face{
@@ -39,11 +69,21 @@
     font-weight: 600;
     font-style: normal;
     font-stretch: normal;
-    src: url('EOT/SourceSerifPro-Semibold.eot') format('embedded-opentype'),
+    src: url('WOFF2/TTF/SourceSerifPro-Semibold.ttf.woff2') format('woff2'),
          url('WOFF/OTF/SourceSerifPro-Semibold.otf.woff') format('woff'),
-         url('WOFF2/OTF/SourceSerifPro-Semibold.otf.woff2') format('woff2'),
          url('OTF/SourceSerifPro-Semibold.otf') format('opentype'),
          url('TTF/SourceSerifPro-Semibold.ttf') format('truetype');
+}
+
+@font-face{
+    font-family: 'Source Serif Pro';
+    font-weight: 600;
+    font-style: italic;
+    font-stretch: normal;
+    src: url('WOFF2/TTF/SourceSerifPro-SemiboldIt.ttf.woff2') format('woff2'),
+         url('WOFF/OTF/SourceSerifPro-SemiboldIt.otf.woff') format('woff'),
+         url('OTF/SourceSerifPro-SemiboldIt.otf') format('opentype'),
+         url('TTF/SourceSerifPro-SemiboldIt.ttf') format('truetype');
 }
 
 @font-face{
@@ -51,11 +91,21 @@
     font-weight: 700;
     font-style: normal;
     font-stretch: normal;
-    src: url('EOT/SourceSerifPro-Bold.eot') format('embedded-opentype'),
+    src: url('WOFF2/TTF/SourceSerifPro-Bold.ttf.woff2') format('woff2'),
          url('WOFF/OTF/SourceSerifPro-Bold.otf.woff') format('woff'),
-         url('WOFF2/OTF/SourceSerifPro-Bold.otf.woff2') format('woff2'),
          url('OTF/SourceSerifPro-Bold.otf') format('opentype'),
          url('TTF/SourceSerifPro-Bold.ttf') format('truetype');
+}
+
+@font-face{
+    font-family: 'Source Serif Pro';
+    font-weight: 700;
+    font-style: italic;
+    font-stretch: normal;
+    src: url('WOFF2/TTF/SourceSerifPro-BoldIt.ttf.woff2') format('woff2'),
+         url('WOFF/OTF/SourceSerifPro-BoldIt.otf.woff') format('woff'),
+         url('OTF/SourceSerifPro-BoldIt.otf') format('opentype'),
+         url('TTF/SourceSerifPro-BoldIt.ttf') format('truetype');
 }
 
 @font-face{
@@ -63,9 +113,19 @@
     font-weight: 900;
     font-style: normal;
     font-stretch: normal;
-    src: url('EOT/SourceSerifPro-Black.eot') format('embedded-opentype'),
+    src: url('WOFF2/TTF/SourceSerifPro-Black.ttf.woff2') format('woff2'),
          url('WOFF/OTF/SourceSerifPro-Black.otf.woff') format('woff'),
-         url('WOFF2/OTF/SourceSerifPro-Black.otf.woff2') format('woff2'),
          url('OTF/SourceSerifPro-Black.otf') format('opentype'),
          url('TTF/SourceSerifPro-Black.ttf') format('truetype');
+}
+
+@font-face{
+    font-family: 'Source Serif Pro';
+    font-weight: 900;
+    font-style: italic;
+    font-stretch: normal;
+    src: url('WOFF2/TTF/SourceSerifPro-BlackIt.ttf.woff2') format('woff2'),
+         url('WOFF/OTF/SourceSerifPro-BlackIt.otf.woff') format('woff'),
+         url('OTF/SourceSerifPro-BlackIt.otf') format('opentype'),
+         url('TTF/SourceSerifPro-BlackIt.ttf') format('truetype');
 }


### PR DESCRIPTION
The browser was displaying only fake slanted styles instead of your shiny, beautiful italics. Let us fix it!