### PR TITLE
Fix branch name in README: "master" → "main"

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ is a set of OpenType fonts to complement the
 
 ## Open source files
 
-The fonts' source files and build instructions are available in the [repository's `master` branch](https://github.com/adobe-fonts/source-serif-pro/tree/master).
+The fonts' source files and build instructions are available in the [repository's `main` branch](https://github.com/adobe-fonts/source-serif-pro/tree/main).
 
 ## Getting involved
 


### PR DESCRIPTION
What the title says :) The [current link](https://github.com/adobe-fonts/source-serif-pro/tree/master) points to a nonexistent page.